### PR TITLE
fixes the fingerprint being returned at payload signing time

### DIFF
--- a/attestationpayload.go
+++ b/attestationpayload.go
@@ -1,8 +1,6 @@
 package voucher
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // AttestationPayload is a structure that contains the Attestation data that we
 // want to create an Occurrence from.
@@ -18,12 +16,9 @@ func (payload *AttestationPayload) Sign(keyring *KeyRing) (string, string, error
 		return "", "", err
 	}
 
-	// create the hex version of the KeyID.
-	keyID := fmt.Sprintf("%#x", signer.PrimaryKey.KeyId)
-
 	signature, err := Sign(signer, payload.Body)
 
-	return signature, keyID, err
+	return signature, fmt.Sprintf("%X", signer.PrimaryKey.Fingerprint), err
 }
 
 // NewAttestationPayload creates a new AttestationPayload for the check with the passed name,

--- a/attestationpayload_test.go
+++ b/attestationpayload_test.go
@@ -1,0 +1,36 @@
+package voucher
+
+import "testing"
+
+func TestAttestationPayload(t *testing.T) {
+	payloadMessage := "test was successful"
+
+	keyring, err := EjsonToKeyRing("tests/fixtures/key", "tests/fixtures/test.ejson")
+	if nil != err {
+		t.Fatalf("Failed to get keys from ejson: %s", err)
+	}
+
+	payload := AttestationPayload{
+		CheckName: "snakeoil",
+		Body:      payloadMessage,
+	}
+
+	result, fingerprint, err := payload.Sign(keyring)
+	if nil != err {
+		t.Fatalf("Failed to sign attestation: %s", err)
+	}
+
+	if snakeoilKeyFingerprint != fingerprint {
+		t.Fatalf("Failed to get correct fingerprint, was %s vs %s", fingerprint, snakeoilKeyFingerprint)
+	}
+
+	message, err := Verify(keyring, result)
+	if nil != err {
+		t.Fatalf("Failed to verify result: %s", result)
+	}
+
+	if message != payloadMessage {
+		t.Fatalf("Failed to get correct message, was \"%s\" instead of \"%s\"", message, payloadMessage)
+	}
+
+}

--- a/grafeas/client.go
+++ b/grafeas/client.go
@@ -96,7 +96,8 @@ func (g *Client) getOccurrenceAttestation(signature string, keyID string) *conta
 func (g *Client) getCreateOccurrenceRequest(reference reference.Reference, parentNoteID string, attestation *containeranalysispb.Occurrence_Attestation) *containeranalysispb.CreateOccurrenceRequest {
 	binauthProjectPath := "projects/" + g.binauthProject
 	noteName := binauthProjectPath + "/notes/" + parentNoteID
-	occurrence := containeranalysispb.Occurrence{NoteName: noteName, ResourceUrl: reference.String(), Details: attestation}
+	resourceURL := "https://" + reference.String()
+	occurrence := containeranalysispb.Occurrence{NoteName: noteName, ResourceUrl: resourceURL, Details: attestation}
 	req := &containeranalysispb.CreateOccurrenceRequest{Parent: binauthProjectPath, Occurrence: &occurrence}
 	return req
 }

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 const snakeoilKeyID = "1E92E2B4BB73E885"
-
+const snakeoilKeyFingerprint = "90E942641C07A4C466BA97161E92E2B4BB73E885"
 const testSignedValue = "test value to sign"
 
 func TestGetKey(t *testing.T) {


### PR DESCRIPTION
This change should fix the fingerprint being returned for new attestations (uses the full fingerprint instead of the "long ID"). This change also adds tests for AttestationPayload.