### PR TITLE
moves Request (formerly Params) out of server subpackage

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/Shopify/voucher"
-	"github.com/Shopify/voucher/server"
 	"github.com/docker/distribution/reference"
 )
 
@@ -30,7 +29,7 @@ func (c *VoucherClient) Check(check string, image reference.Canonical) (voucher.
 	var checkResp voucher.Response
 	var buffer bytes.Buffer
 
-	err := json.NewEncoder(&buffer).Encode(server.VoucherParams{
+	err := json.NewEncoder(&buffer).Encode(voucher.Request{
 		ImageURL: image.String(),
 	})
 	if err != nil {

--- a/request.go
+++ b/request.go
@@ -1,0 +1,6 @@
+package voucher
+
+// Request describes the Voucher API request structure.
+type Request struct {
+	ImageURL string `json:"image_url"`
+}

--- a/server/input.go
+++ b/server/input.go
@@ -7,19 +7,14 @@ import (
 	"github.com/Shopify/voucher"
 )
 
-// VoucherParams describes the input structure.
-type VoucherParams struct {
-	ImageURL string `json:"image_url"`
-}
-
 func handleInput(r *http.Request) (imageData voucher.ImageData, err error) {
-	var params VoucherParams
+	var request voucher.Request
 
-	err = json.NewDecoder(r.Body).Decode(&params)
+	err = json.NewDecoder(r.Body).Decode(&request)
 	if nil != err {
 		return
 	}
 
-	imageData, err = voucher.NewImageData(params.ImageURL)
+	imageData, err = voucher.NewImageData(request.ImageURL)
 	return
 }


### PR DESCRIPTION
This change fixes importing "voucher/client" so it doesn't pull in all of "voucher/server".