### PR TITLE
docker/schema2: support manifest lists

### DIFF
--- a/v2/clair/clair.go
+++ b/v2/clair/clair.go
@@ -2,6 +2,7 @@ package clair
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -142,7 +143,8 @@ func getClairVulnerabilities(manifest distribution.Manifest, config Config, toke
 
 	switch {
 	case s2.IsManifest(manifest):
-		m, mfErr := s2.ToManifest(manifest)
+		client := oauth2.NewClient(context.TODO(), tokenSrc)
+		m, mfErr := s2.ToManifest(client, image, manifest)
 		if mfErr != nil {
 			return nil, fmt.Errorf("fetching manifest: %w", mfErr)
 		}

--- a/v2/clair/clair.go
+++ b/v2/clair/clair.go
@@ -142,7 +142,10 @@ func getClairVulnerabilities(manifest distribution.Manifest, config Config, toke
 
 	switch {
 	case s2.IsManifest(manifest):
-		m := s2.ToManifest(manifest)
+		m, mfErr := s2.ToManifest(manifest)
+		if mfErr != nil {
+			return nil, fmt.Errorf("fetching manifest: %w", mfErr)
+		}
 
 		vulns, err = getSchema2Layers(m, config, tokenSrc, image, parent)
 	case s1.IsManifest(manifest):

--- a/v2/docker/manifest.go
+++ b/v2/docker/manifest.go
@@ -17,7 +17,7 @@ import (
 func RequestManifest(client *http.Client, ref reference.Canonical) (distribution.Manifest, error) {
 	var manifest distribution.Manifest
 
-	request, err := http.NewRequest(http.MethodGet, uri.GetManifestURI(ref), nil)
+	request, err := http.NewRequest(http.MethodGet, uri.GetDigestManifestURI(ref), nil)
 	if nil != err {
 		return nil, err
 	}

--- a/v2/docker/manifest.go
+++ b/v2/docker/manifest.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/reference"
@@ -22,6 +23,7 @@ func RequestManifest(client *http.Client, ref reference.Canonical) (distribution
 		return nil, err
 	}
 
+	request.Header.Add("Accept", manifestlist.MediaTypeManifestList)
 	request.Header.Add("Accept", schema2.MediaTypeManifest)
 	request.Header.Add("Accept", schema1.MediaTypeManifest)
 	request.Header.Add("Accept", schema1.MediaTypeSignedManifest)

--- a/v2/docker/manifest_test.go
+++ b/v2/docker/manifest_test.go
@@ -1,10 +1,14 @@
 package docker
 
 import (
+	"context"
+	"os"
 	"testing"
 
+	"github.com/docker/distribution/reference"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 
 	"github.com/grafeas/voucher/v2/docker/schema2"
 	vtesting "github.com/grafeas/voucher/v2/testing"
@@ -55,4 +59,16 @@ func TestRateLimitedBadManifest(t *testing.T) {
 		NewManifestErrorWithRequest("200 OK", []byte(vtesting.RateLimitOutput+"\n")),
 		err,
 	)
+}
+
+func TestRequestManifestList(t *testing.T) {
+	// FIXME: follow the stubbed hub style of the abov ; oreilly-well-do-it-live.jpg
+	token := &oauth2.Token{AccessToken: os.Getenv("REGISTRY_TOKEN")}
+	c := oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(token))
+	ref, err := reference.Parse("registry.k8s.pwagner.net/dockerhub/library/ubuntu@sha256:cc8f713078bfddfe9ace41e29eb73298f52b2c958ccacd1b376b9378e20906ef")
+	require.NoError(t, err)
+
+	ic, err := RequestImageConfig(c, ref.(reference.Canonical))
+	require.NoError(t, err)
+	assert.True(t, ic.RunsAsRoot())
 }

--- a/v2/docker/manifest_test.go
+++ b/v2/docker/manifest_test.go
@@ -19,7 +19,8 @@ func TestRequestManifest(t *testing.T) {
 	manifest, err := RequestManifest(client, ref)
 	require.NoError(t, err)
 
-	schema2Manifest := schema2.ToManifest(manifest)
+	schema2Manifest, err := schema2.ToManifest(manifest)
+	require.NoError(t, err)
 
 	assert.Equal(
 		t,

--- a/v2/docker/manifest_test.go
+++ b/v2/docker/manifest_test.go
@@ -19,7 +19,7 @@ func TestRequestManifest(t *testing.T) {
 	manifest, err := RequestManifest(client, ref)
 	require.NoError(t, err)
 
-	schema2Manifest, err := schema2.ToManifest(manifest)
+	schema2Manifest, err := schema2.ToManifest(client, ref, manifest)
 	require.NoError(t, err)
 
 	assert.Equal(

--- a/v2/docker/manifest_test.go
+++ b/v2/docker/manifest_test.go
@@ -1,14 +1,10 @@
 package docker
 
 import (
-	"context"
-	"os"
 	"testing"
 
-	"github.com/docker/distribution/reference"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/oauth2"
 
 	"github.com/grafeas/voucher/v2/docker/schema2"
 	vtesting "github.com/grafeas/voucher/v2/testing"
@@ -62,13 +58,20 @@ func TestRateLimitedBadManifest(t *testing.T) {
 }
 
 func TestRequestManifestList(t *testing.T) {
-	// FIXME: follow the stubbed hub style of the abov ; oreilly-well-do-it-live.jpg
-	token := &oauth2.Token{AccessToken: os.Getenv("REGISTRY_TOKEN")}
-	c := oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(token))
-	ref, err := reference.Parse("registry.k8s.pwagner.net/dockerhub/library/ubuntu@sha256:cc8f713078bfddfe9ace41e29eb73298f52b2c958ccacd1b376b9378e20906ef")
+	ref := vtesting.NewTestManifestListReference(t)
+
+	client, server := vtesting.PrepareDockerTest(t, ref)
+	defer server.Close()
+
+	manifest, err := RequestManifest(client, ref)
 	require.NoError(t, err)
 
-	ic, err := RequestImageConfig(c, ref.(reference.Canonical))
+	schema2Manifest, err := schema2.ToManifest(client, ref, manifest)
 	require.NoError(t, err)
-	assert.True(t, ic.RunsAsRoot())
+
+	assert.Equal(
+		t,
+		vtesting.NewTestManifest().Manifest,
+		schema2Manifest,
+	)
 }

--- a/v2/docker/schema2/config.go
+++ b/v2/docker/schema2/config.go
@@ -24,7 +24,7 @@ func RequestConfig(client *http.Client, ref reference.Canonical, manifest distri
 		return nil, errors.New("cannot request schema2 config for non-schema2 manifest")
 	}
 
-	v2Manifest, err := ToManifest(manifest)
+	v2Manifest, err := ToManifest(client, ref, manifest)
 	if err != nil {
 		return nil, fmt.Errorf("fetching manifest: %w", err)
 	}

--- a/v2/docker/schema2/config.go
+++ b/v2/docker/schema2/config.go
@@ -3,6 +3,7 @@ package schema2
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/docker/distribution"
@@ -23,7 +24,10 @@ func RequestConfig(client *http.Client, ref reference.Canonical, manifest distri
 		return nil, errors.New("cannot request schema2 config for non-schema2 manifest")
 	}
 
-	v2Manifest := ToManifest(manifest)
+	v2Manifest, err := ToManifest(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("fetching manifest: %w", err)
+	}
 
 	var wrapper v2Blob
 

--- a/v2/docker/schema2/manifest.go
+++ b/v2/docker/schema2/manifest.go
@@ -2,10 +2,13 @@ package schema2
 
 import (
 	"fmt"
+	"net/http"
+	"os"
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
 	v2 "github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/distribution/reference"
 )
 
 // IsManifest returns true if the passed manifest is a schema2 manifest.
@@ -20,14 +23,39 @@ func IsManifest(m distribution.Manifest) bool {
 
 // ToManifest casts a distribution.Manifest to a schema2.Manifest. It panics
 // if it passed anything other than a schema2.DeserialzedManifest.
-func ToManifest(manifest distribution.Manifest) (v2.Manifest, error) {
+func ToManifest(client *http.Client, ref reference.Named, manifest distribution.Manifest) (v2.Manifest, error) {
 	switch m := manifest.(type) {
 	case *v2.DeserializedManifest:
 		return m.Manifest, nil
 	case *manifestlist.DeserializedManifestList:
-		// TODO
-		return v2.Manifest{}, fmt.Errorf("implement me")
+		return resolveManifestFromList(client, ref, m)
 	default:
 		return v2.Manifest{}, fmt.Errorf("schema2.ToManifest was passed a %T", manifest)
 	}
+}
+
+// Ugly method to override the target os/arch without wiring the voucher config to this context
+var targetOS, targetArch string
+
+func init() {
+	targetOS = os.Getenv("VOUCHER_TARGET_OS")
+	if targetOS == "" {
+		targetOS = "linux"
+	}
+	targetArch = os.Getenv("VOUCHER_TARGET_ARCH")
+	if targetArch == "" {
+		targetArch = "amd64"
+	}
+}
+
+func resolveManifestFromList(client *http.Client, ref reference.Named, mfs *manifestlist.DeserializedManifestList) (v2.Manifest, error) {
+	for _, mf := range mfs.Manifests {
+		if mf.Platform.Architecture != targetArch || mf.Platform.OS != targetOS {
+			continue
+		}
+
+		// TODO: use the client and the fancy new uri.Manifest helper to grab this platform's manifest, return that
+		// that's doable - this commit is focussed on wiring dependencies to this function
+	}
+	return v2.Manifest{}, fmt.Errorf("no manifest matching %s/%s found", targetOS, targetArch)
 }

--- a/v2/docker/schema2/manifest.go
+++ b/v2/docker/schema2/manifest.go
@@ -1,23 +1,33 @@
 package schema2
 
 import (
+	"fmt"
+
 	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/manifestlist"
 	v2 "github.com/docker/distribution/manifest/schema2"
 )
 
 // IsManifest returns true if the passed manifest is a schema2 manifest.
 func IsManifest(m distribution.Manifest) bool {
-	_, ok := m.(*v2.DeserializedManifest)
-	return ok
+	switch m.(type) {
+	case *v2.DeserializedManifest, *manifestlist.DeserializedManifestList:
+		return true
+	default:
+		return false
+	}
 }
 
 // ToManifest casts a distribution.Manifest to a schema2.Manifest. It panics
 // if it passed anything other than a schema2.DeserialzedManifest.
-func ToManifest(manifest distribution.Manifest) v2.Manifest {
-	schema2Manifest, ok := manifest.(*v2.DeserializedManifest)
-	if !ok {
-		panic("schema2.ToManifest was passed a non-schema2.DeserializedManifest")
+func ToManifest(manifest distribution.Manifest) (v2.Manifest, error) {
+	switch m := manifest.(type) {
+	case *v2.DeserializedManifest:
+		return m.Manifest, nil
+	case *manifestlist.DeserializedManifestList:
+		// TODO
+		return v2.Manifest{}, fmt.Errorf("implement me")
+	default:
+		return v2.Manifest{}, fmt.Errorf("schema2.ToManifest was passed a %T", manifest)
 	}
-
-	return schema2Manifest.Manifest
 }

--- a/v2/docker/schema2/manifest_test.go
+++ b/v2/docker/schema2/manifest_test.go
@@ -12,7 +12,7 @@ import (
 func TestToManifest(t *testing.T) {
 	newManifest := vtesting.NewTestManifest()
 
-	manifest, err := ToManifest(newManifest)
+	manifest, err := ToManifest(nil, nil, newManifest)
 	require.NoError(t, err)
 	assert.NotNil(t, manifest)
 }

--- a/v2/docker/schema2/manifest_test.go
+++ b/v2/docker/schema2/manifest_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	vtesting "github.com/grafeas/voucher/v2/testing"
 )
@@ -11,6 +12,7 @@ import (
 func TestToManifest(t *testing.T) {
 	newManifest := vtesting.NewTestManifest()
 
-	manifest := ToManifest(newManifest)
+	manifest, err := ToManifest(newManifest)
+	require.NoError(t, err)
 	assert.NotNil(t, manifest)
 }

--- a/v2/docker/uri/uri.go
+++ b/v2/docker/uri/uri.go
@@ -30,25 +30,22 @@ func GetBlobURI(ref reference.Named, digest digest.Digest) string {
 	return u.String()
 }
 
-// GetManifestURI gets a manifest URI based on the passed repository and
-// digest.
-func GetManifestURI(ref reference.Canonical) string {
-	u := createURL(ref, reference.Path(ref), "manifests", string(ref.Digest()))
+// GetManifestURI gets a manifest URI based on the passed repository and label (tag or digest).
+func GetManifestURI(ref reference.Named, label string) string {
+	u := createURL(ref, reference.Path(ref), "manifests", label)
 	return u.String()
 }
 
 // GetTagManifestURI gets a manifest URI based on the passed repository and
 // tag.
 func GetTagManifestURI(ref reference.NamedTagged) string {
-	u := createURL(ref, reference.Path(ref), "manifests", ref.Tag())
-	return u.String()
+	return GetManifestURI(ref, ref.Tag())
 }
 
 // GetDigestManifestURI gets a manifest URI based on the passed repository and
-// tag.
+// digest.
 func GetDigestManifestURI(ref reference.Canonical) string {
-	u := createURL(ref, reference.Path(ref), "manifests", string(ref.Digest()))
-	return u.String()
+	return GetManifestURI(ref, string(ref.Digest()))
 }
 
 func createURL(ref reference.Named, pathSegments ...string) url.URL {

--- a/v2/docker/uri/uri_test.go
+++ b/v2/docker/uri/uri_test.go
@@ -31,5 +31,5 @@ func TestGetBaseURI(t *testing.T) {
 	assert.Equal(t, hostname, "gcr.io")
 	assert.Equal(t, path, testProject)
 	assert.Equal(t, testBlobURL, GetBlobURI(canonicalRef, canonicalRef.Digest()))
-	assert.Equal(t, testManifestURL, GetManifestURI(canonicalRef))
+	assert.Equal(t, testManifestURL, GetDigestManifestURI(canonicalRef))
 }

--- a/v2/testing/docker.go
+++ b/v2/testing/docker.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
 	dockerTypes "github.com/docker/docker/api/types"
@@ -56,6 +57,9 @@ func (mock *dockerAPIMock) ServeHTTP(writer http.ResponseWriter, req *http.Reque
 		return
 	case "/v2/path/to/image/blobs/sha256:b5b2b2c507a0944348e0303114d8d93bbbb081732b86451d9bce1f432a537bc7":
 		jsonRespond(writer, schema2.MediaTypeImageConfig, NewTestRootImageConfig())
+		return
+	case "/v2/path/to/image/manifests/sha256:fefafefa52ba402ed7dd98d73f5a41836ece508d1f4704b274562ac0c9b3b7da":
+		jsonRespond(writer, manifestlist.MediaTypeManifestList, NewTestManifestList())
 		return
 	}
 

--- a/v2/testing/manifests.go
+++ b/v2/testing/manifests.go
@@ -2,6 +2,8 @@ package vtesting
 
 import (
 	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/libtrust"
@@ -43,6 +45,40 @@ func NewTestManifest() *schema2.DeserializedManifest {
 	}
 
 	return newManifest
+}
+
+func NewTestManifestList() *manifestlist.ManifestList {
+	return &manifestlist.ManifestList{
+		Versioned: manifest.Versioned{
+			MediaType: manifestlist.MediaTypeManifestList,
+		},
+		Manifests: []manifestlist.ManifestDescriptor{
+			// Wrong arch
+			{
+				Platform: manifestlist.PlatformSpec{
+					OS:           "linux",
+					Architecture: "arm64",
+				},
+			},
+			// Wrong OS
+			{
+				Platform: manifestlist.PlatformSpec{
+					OS:           "windows",
+					Architecture: "amd64",
+				},
+			},
+			// Matched manifest
+			{
+				Platform: manifestlist.PlatformSpec{
+					OS:           "linux",
+					Architecture: "amd64",
+				},
+				Descriptor: distribution.Descriptor{
+					Digest: "sha256:b148c8af52ba402ed7dd98d73f5a41836ece508d1f4704b274562ac0c9b3b7da",
+				},
+			},
+		},
+	}
 }
 
 // NewTestRootManifest creates a test schema2 manifest for our mock Docker API, which points to an image whose user is configured to be root

--- a/v2/testing/reference.go
+++ b/v2/testing/reference.go
@@ -16,6 +16,14 @@ func NewTestReference(t *testing.T) reference.Canonical {
 	return parseReference(t, "localhost/path/to/image@sha256:b148c8af52ba402ed7dd98d73f5a41836ece508d1f4704b274562ac0c9b3b7da")
 }
 
+// NewTestManifestListReference creates a new reference to be used throughout the docker tests.
+// The returned reference is assumed to be a manifest list, with images for multiple platforms.
+func NewTestManifestListReference(t *testing.T) reference.Canonical {
+	t.Helper()
+
+	return parseReference(t, "localhost/path/to/image@sha256:fefafefa52ba402ed7dd98d73f5a41836ece508d1f4704b274562ac0c9b3b7da")
+}
+
 // NewBadTestReference creates a new reference to be used throughout the docker tests.
 // The returned reference is assumed to not, and does not have valid configuration
 // or layers.


### PR DESCRIPTION
The [image manifest v2](https://docs.docker.com/registry/spec/manifest-v2-2/) allows returning an "manifest list", containing references to multiple manifests for distinct [platforms](https://github.com/containerd/containerd/blob/main/platforms/platforms.go). This is how a single image can represent multiple architectures.

Voucher should eventually support manifest lists, but doing so is a large refactor: many `Manifest` and `ImageConfig` objects become `[]Manifest` and `[]ImageConfig`.

This PR is aiming to "support" manifest lists rather quickly, by discarding all but a single target architecture (by default: `linux/amd64`, but it can be overridden by environment variables, I did not wire the configuration file through 🤢). This allows voucher to vouch for the `linux/amd64` platform of multi-arch images.

~A similar change will be required for any systems that resolve these images to vouched digests at deploy time. Until that happens, these images will be vouch-able but not deploy-able.~ Other systems will query by image label, and get fallback behaviour from the registry.

⚠️ We do not intend to send this functionality to https://github.com/grafeas/voucher ; we'll use this fork until full manifest list support is added (probably 1-2months)

# Related
- https://github.com/grafeas/voucher/issues/47