### PR TITLE
Improve error msg when missing sbom

### DIFF
--- a/v2/sbomgcr/client.go
+++ b/v2/sbomgcr/client.go
@@ -75,7 +75,7 @@ func (c *Client) GetSBOM(ctx context.Context, imageName, tag string) (cyclonedx.
 	sbomDigest, err := GetSBOMDigestWithTag(imageName, tags, tag)
 
 	if err != nil {
-		return cyclonedx.BOM{}, fmt.Errorf("error getting digest with tag %w", err)
+		return cyclonedx.BOM{}, fmt.Errorf("error getting digest with tag %w, are you sure the image: %s, has an sbom?", err, imageName)
 	}
 
 	sbomName := imageName + "@" + sbomDigest

--- a/v2/sbomgcr/client.go
+++ b/v2/sbomgcr/client.go
@@ -75,7 +75,7 @@ func (c *Client) GetSBOM(ctx context.Context, imageName, tag string) (cyclonedx.
 	sbomDigest, err := GetSBOMDigestWithTag(imageName, tags, tag)
 
 	if err != nil {
-		return cyclonedx.BOM{}, fmt.Errorf("error getting digest with tag %w, are you sure the image: %s, has an sbom?", err, imageName)
+		return cyclonedx.BOM{}, fmt.Errorf("error getting digest with tag: %w, are you sure the image: %s, has an sbom, check your images for one with this tag: %s?", err, imageName, tag)
 	}
 
 	sbomName := imageName + "@" + sbomDigest


### PR DESCRIPTION
While working with @rxbchen yesterday, he pointed out that the error message provided when the image didn't have an sbom wasn't very helpful / clear.

This one liner helps to add some more info for the user when this error occurs.

Current error message:

<img width="731" alt="Screen Shot 2022-06-07 at 9 37 59 AM" src="https://user-images.githubusercontent.com/47957189/172394314-aae80b68-86ce-4378-863d-8bb97913ce1c.png">


The new one will guide the user to check the image in their gcr and see if the sbom exists for that image.

